### PR TITLE
feat: add you.com search provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,35 @@ Tips for creating effective tools:
 - Handle errors gracefully and return informative error messages.
 - Consider adding type definitions for complex input/output structures.
 
+## You.com Search Tool (optional provider)
+
+This repo now includes a built-in `fetch_you_search` sample tool for web search-backed agents.
+
+Setup:
+
+```bash
+# Optional (tool also works with a limited unauthenticated quota)
+export YDC_API_KEY=your_key_here
+```
+
+Usage:
+
+```typescript
+import Agent from "src/lib/agent";
+import FetchYouSearch from "src/tools/sample/FetchYouSearch";
+
+export default Agent.create({
+  name: "Web Research Agent",
+  prompt: "Use fetch_you_search to gather current web evidence before answering.",
+  tools: [FetchYouSearch],
+});
+```
+
+Behavior notes:
+- Uses `https://api.you.com/v1/agents/search` with `query` + `count`.
+- Uses `X-API-Key` when provided via tool input or `YDC_API_KEY`.
+- Returns `{ error, results: [] }` when the provider returns a non-2xx status, so agents can recover gracefully.
+
 ### Toolmaker Mode
 
 easy-agent comes bundled with an agent named Toolmaker, which can make tools for your agents.

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,5 +1,6 @@
 export { default as CreateTool } from "./sample/CreateTool";
 export { default as FetchGoogleSERP } from "./sample/FetchGoogleSERP";
+export { default as FetchYouSearch } from "./sample/FetchYouSearch";
 export { default as FetchHTML } from "./sample/FetchHTML";
 export { default as FetchWeatherByZip } from "./sample/FetchWeatherByZip";
 export { default as FetchWebsiteText } from "./sample/FetchWebsiteText";

--- a/src/tools/sample/FetchYouSearch.test.ts
+++ b/src/tools/sample/FetchYouSearch.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, mock } from "bun:test";
+
+import FetchYouSearch, { normalizeYouResults } from "./FetchYouSearch";
+
+describe("FetchYouSearch", () => {
+  it("normalizes results.web payload", () => {
+    const normalized = normalizeYouResults({
+      results: {
+        web: [
+          {
+            title: "OpenAI",
+            url: "https://openai.com",
+            snippets: ["AI company"],
+          },
+        ],
+      },
+    });
+
+    expect(normalized).toEqual([
+      {
+        title: "OpenAI",
+        url: "https://openai.com",
+        snippet: "AI company",
+      },
+    ]);
+  });
+
+  it("returns structured error on non-200 responses", async () => {
+    const fetchMock = mock(async () => new Response("{}", { status: 403 }));
+    (globalThis as any).fetch = fetchMock;
+
+    const result = await FetchYouSearch.callFn({ query: "openai" });
+
+    expect(result).toEqual({
+      error: "you.com search failed with status 403",
+      results: [],
+    });
+  });
+});
+

--- a/src/tools/sample/FetchYouSearch.ts
+++ b/src/tools/sample/FetchYouSearch.ts
@@ -1,0 +1,71 @@
+import Tool from "src/lib/tool";
+
+type YouSearchResult = {
+  title?: string;
+  url?: string;
+  snippets?: string[];
+  description?: string;
+};
+
+export function normalizeYouResults(payload: unknown) {
+  const webResults =
+    (payload as { results?: { web?: YouSearchResult[] } })?.results?.web ?? [];
+
+  return webResults
+    .map((item) => ({
+      title: item.title ?? item.url ?? "Untitled",
+      url: item.url ?? "",
+      snippet: item.snippets?.[0] ?? item.description ?? "",
+    }))
+    .filter((item) => item.url);
+}
+
+export default Tool.create({
+  name: "fetch_you_search",
+  description:
+    "Search the web with You.com Search API and return normalized results for agent reasoning.",
+  inputs: [
+    {
+      name: "query",
+      type: "string",
+      description: "Search query text",
+      required: true,
+    },
+    {
+      name: "count",
+      type: "number",
+      description: "How many results to fetch (default 5)",
+    },
+    {
+      name: "apiKey",
+      type: "string",
+      description: "Optional You.com API key. Falls back to YDC_API_KEY env var.",
+    },
+  ],
+  fn: async ({ query, count = 5, apiKey }) => {
+    const effectiveApiKey = apiKey || process.env.YDC_API_KEY;
+    const url = new URL("https://api.you.com/v1/agents/search");
+    url.searchParams.set("query", query);
+    url.searchParams.set("count", String(count));
+
+    const response = await fetch(url.toString(), {
+      headers: {
+        Accept: "application/json",
+        ...(effectiveApiKey ? { "X-API-Key": effectiveApiKey } : {}),
+      },
+    });
+
+    if (!response.ok) {
+      return {
+        error: `you.com search failed with status ${response.status}`,
+        results: [],
+      };
+    }
+
+    const data = await response.json();
+    return {
+      results: normalizeYouResults(data),
+    };
+  },
+});
+


### PR DESCRIPTION
Thanks for building easy-agent, the project is refreshingly simple and a great fit for tool-oriented agent workflows.

I picked this repo because it is a lightweight agent framework where web search is a natural capability, and adding an optional search provider can improve real-world research tasks without changing core abstractions.

## What changed
- Added a new optional built-in sample tool: `fetch_you_search`
  - file: `src/tools/sample/FetchYouSearch.ts`
  - endpoint: `https://api.you.com/v1/agents/search`
  - request params: `query` + `count`
  - auth: optional `X-API-Key` from tool input `apiKey` or `YDC_API_KEY`
- Added normalization helper for `results.web` payload shape.
- Added graceful fallback behavior for provider failures:
  - returns `{ error, results: [] }` on non-2xx responses.
- Exported the tool from `src/tools/index.ts`.
- Added docs in `README.md`:
  - env setup
  - usage example in an agent
  - behavior notes
- Added tests:
  - `src/tools/sample/FetchYouSearch.test.ts`

## Setup
```bash
# optional (tool can run with limited unauthenticated quota)
export YDC_API_KEY=your_key_here
```

Then register in an agent:
```ts
import FetchYouSearch from "src/tools/sample/FetchYouSearch";
```

## Validation
- Added focused tests for result normalization and non-2xx error handling.
- I was not able to execute `bun test` in this environment because `bun` is not installed on this runner (`/bin/sh: bun: command not found`).

## Compatibility / risk
- Backward compatible: no existing tool behavior changed.
- Additive only: introduces a new optional tool and README documentation.

If you prefer different naming/location (for example under a dedicated `search/` folder), I’m happy to adjust quickly. EOF

gh pr create --repo zcaceres/easy-agent --head mouse-value-add:feat/you-search-provider --base main --title "feat: add you.com search provider" --body-file /tmp/easy-agent-pr-body.md
